### PR TITLE
(fix) declare bearer token correctly for pkcs12

### DIFF
--- a/lib/adal/token_request.rb
+++ b/lib/adal/token_request.rb
@@ -45,7 +45,7 @@ module ADAL
     module GrantType
       AUTHORIZATION_CODE = 'authorization_code'
       CLIENT_CREDENTIALS = 'client_credentials'
-      JWT_BEARER = 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+      JWT_BEARER = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
       PASSWORD = 'password'
       REFRESH_TOKEN = 'refresh_token'
       SAML1 = 'urn:ietf:params:oauth:grant-type:saml1_1-bearer'

--- a/spec/adal/client_assertion_certificate_spec.rb
+++ b/spec/adal/client_assertion_certificate_spec.rb
@@ -99,7 +99,7 @@ describe ADAL::ClientAssertionCertificate do
     it 'should have client assertion type be JWT_BEARER' do
       expect(
         @assertion_cert.request_params[:client_assertion_type]
-      ).to eq('urn:ietf:params:oauth:grant-type:jwt-bearer')
+      ).to eq('urn:ietf:params:oauth:client-assertion-type:jwt-bearer')
     end
 
     it 'should have an assertion that is a decodable JWT' do


### PR DESCRIPTION
see https://github.com/AzureAD/azure-activedirectory-library-for-ruby/issues/55#issuecomment-323721291